### PR TITLE
Hardcode the names and links back in the posts

### DIFF
--- a/_posts/2013-11-09-announcing-associate-sponsor-mavenhive.md
+++ b/_posts/2013-11-09-announcing-associate-sponsor-mavenhive.md
@@ -11,4 +11,6 @@ sponsor_url: http://www.mavenhive.in/
 sponsor_quote: "MavenHive is a boutique consulting firm which offers expert technical consulting to global startups. Led by a core team of professionals with almost a decade of average experience with Agile and a variety of technologies, we offer proven expertise with leading technologies and build solutions which meet the highest quality requirements of the industry."
 ---
 
-Thanks to <a href="{{ page.sponsor_url }}" target="_blank">{{ page.sponsor_name }}</a> for signing up to be an Associate Sponsor at #GCRC. <a href="{{ page.sponsor_url }}" target="_blank">{{ page.sponsor_name }}</a> has been a regular contributor to the <a href="http://bangaloreruby.org/" target="_blank">Bangalore Ruby Community</a> and has sponsored many ruby conferences in the past.
+Thanks to <a href="//www.mavenhive.in/" target="_blank">MavenHive</a> for signing up to 
+be an Associate Sponsor at #GCRC. MavenHive has been a regular contributor to the 
+<a href="http://bangaloreruby.org/" target="_blank">Bangalore Ruby Community</a> and has sponsored many ruby conferences in the past.

--- a/_posts/2013-11-09-announcing-silver-sponsor-josh-software.md
+++ b/_posts/2013-11-09-announcing-silver-sponsor-josh-software.md
@@ -9,6 +9,8 @@ comments: true
 sponsor_name: Josh Software
 sponsor_url: http://www.joshsoftware.com/
 sponsor_quote: "True to its name, it was an innate enthusiasm and passion for building web solutions in Ruby On Rails that led to the establishment of Josh Software in 2007. With a belief that Programming is An Art, Josh Software has a unique organizational process focused to facilitate high performance, scalability and high-standard code quality. The hand picked Josh Software team of 25 regularly contributes back to the Ruby community."
+excert_seperator: ""
 ---
 
-Thanks to <a href="{{ page.sponsor_url }}" target="_blank">{{ page.sponsor_name }}</a> for signing up to be a Silver Sponsor at #GCRC. Thanks also to <a href="{{ page.sponsor_url }}" target="_blank">{{ page.sponsor_name }}</a> for contributing immensely to the growth of the ruby community in India with its regular sponsoring of ruby conferences and meet-ups in India/Pune.
+Thanks to <a href="//www.joshsoftware.com/" target="_blank">Josh Software</a> for signing up to be a Silver Sponsor at #GCRC and for contributing 
+immensely to the growth of the ruby community in India with its regular sponsoring of ruby conferences and meet-ups in India/Pune.


### PR DESCRIPTION
Jekyll's scope is a little weird. The page object is the global template
object that resides in the root (in this case, the blog/index.html where
    the list of the blogposts are shown) whereas the page object refers
to the YAML frontmatter of the template getting embedded inside the root
page. Better to just hardcode the names since we are writing the names
in the title of the post anyway.
