### PR TITLE
Add css changes from dcca161 and 399a11b to less

### DIFF
--- a/assets/less/style.less
+++ b/assets/less/style.less
@@ -695,6 +695,12 @@ table {
 
 
 #sponsors {
+
+  h2 {
+    color: @link;
+    margin-bottom: 0.5em;
+  }
+
   h4 {
     margin: 1em 0 0.5em 0;
   }
@@ -713,6 +719,18 @@ table {
     background: url("/images/sponsors/code_brahma.png") no-repeat;
     width: 254px;
   }
+
+  #good_work_labs {
+    background: url("/images/sponsors/good_work_labs.png") no-repeat;
+    width: 198px;
+  }
+
+  #parami_soft {
+    background: url("/images/sponsors/parami_soft.png") no-repeat;
+    width: 231px;
+  }
+
+
   ul {
     margin: 0;
     border-bottom: 1px #aaa solid;


### PR DESCRIPTION
The two commits 399a11b9c2551c7a12ab2327127503d58ab7223d and
dcca161578c3ec318b6968779e1c32a25d08f04b made changes directly to
the style.css file which will get overridden everytime the style.less
file is recompiled. By making changes to the .less file and recompiling
it everytime, this may be avoided.

Install the less gem and run "lessc assets/less/style.less >
assets/css/style.css" after making changes in the less file. Commit
both.

TODO: This should be a rake task.
