### PR TITLE
Fix the alignment of logos relative to description

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -920,6 +920,7 @@ table tfoot tr td {
 #sponsors li > a {
   display: inline-block;
   min-width: 30%;
+  vertical-align: text-bottom;
 }
 #sponsors li > p {
   display: inline-block;

--- a/assets/less/style.less
+++ b/assets/less/style.less
@@ -765,6 +765,7 @@ table {
   li > a {
     display: inline-block;
     min-width: 30%;
+    vertical-align: text-bottom;
   }
 
   li > p {


### PR DESCRIPTION
In the sponsors page, the description was at at higher level to the logo
position. Fix that.
